### PR TITLE
chore: FORGE-589 upgrade External Document Picker to BrXM v17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [develop]
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [develop]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  fork-notice:
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fork PR - build skipped
+        run: |
+          echo "::notice::This PR originates from a fork and cannot access repository secrets."
+          echo "The build requires credentials for Bloomreach's private Maven repository."
+
+  build:
+    if: >-
+      github.event_name == 'push' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: write
+      checks: write
+      pull-requests: write
+    uses: bloomreach-forge/ci-workflows/.github/workflows/brxm-ci.yml@v2.0.0
+    secrets:
+      BR_MAVEN_USERNAME: ${{ secrets.BR_MAVEN_USERNAME }}
+      BR_MAVEN_PASSWORD: ${{ secrets.BR_MAVEN_PASSWORD }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,165 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project overview
+
+This is the Bloomreach/Hippo CMS **External Document Picker Base** forge project: reusable building blocks for
+letting CMS editors link a document field (or a folder) to items that live outside the JCR repository (e.g. rows
+in an external system reachable only via REST). It ships three independent picker implementations plus a demo:
+
+- `fieldpicker` — classic Wicket-based CMS plugin for document fields and folder context menus.
+- `richtext-ckeditor` — a CKEditor 4 plugin adding an external-link picker button to the Rich Text Editor.
+- `openui-fieldpicker` — a modern Angular 12 app served as a Hippo **OpenUI** extension (iframe) for document fields.
+- `demo/` — a separate Maven reactor (own parent, `hippo-cms7-release`) that boots a full Hippo CMS + example REST
+  backend to exercise all three pickers end to end. Not part of the root reactor's `<modules>`.
+
+Root reactor parent: `org.onehippo.cms7:hippo-cms7-project:17.0.0`. Project Java target is **21**
+(`project.build.javaVersion` in root `pom.xml`), not the org-wide default.
+
+## Common commands
+
+### Root reactor (fieldpicker + richtext-ckeditor + openui-fieldpicker)
+
+```
+mvn clean install                 # build/test everything (openui-fieldpicker runs its full npm build+test too)
+mvn -pl fieldpicker test          # run only the Wicket/Java module's tests
+mvn -pl fieldpicker test -Dtest=SimpleExternalDocumentCollectionTest   # single Java test class
+```
+
+### Documentation site
+
+Docs live as Maven xdoc sources under `src/site/xdoc/**` and are the authoritative architecture references
+(`field/architecture.xml`, `openui-field/architecture.xml`, `openui-field/spec-of-rest-services.xml`, etc.).
+
+```
+mvn clean site                    # renders to target/site/ (open target/site/index.html)
+mvn -Pgithub.pages clean site     # renders into docs/ for GitHub Pages — only run from the master branch
+```
+
+### richtext-ckeditor (manual/browser testing only — no automated Java tests in this module)
+
+The module has no unit tests; verification is manual via a Jetty server that serves the plugin source
+alongside vendored CKEditor test pages under `src/test/resources/`:
+
+```
+mvn -pl richtext-ckeditor jetty:run   # serves src/main/resources + src/test/resources at http://localhost:8080/
+```
+
+### openui-fieldpicker (Angular 12, driven from Maven via frontend-maven-plugin)
+
+Maven pins Node `v16.19.0` / npm `8.19.3` and runs `npm ci` → `npm run build-prod` → (on `mvn test`)
+`npm test -- --watch=false --browsers ChromeHeadless`. `mvn clean` also removes `node/` and `node_modules/`.
+This module's default Maven goal is `validate`, not `package`, so it must be built explicitly via the root
+reactor or `mvn -pl openui-fieldpicker package`.
+
+For local iteration, run npm/ng directly (respect the `engines` constraint: Node 16, npm 8/9):
+
+```
+cd openui-fieldpicker
+npm ci
+npm start                         # ng serve, local dev server
+npm test                          # ng test — Karma/Jasmine unit tests, watches by default
+npm test -- --watch=false --browsers ChromeHeadless   # matches the Maven-invoked headless run
+ng test --include='**/field-view.component.spec.ts'   # run a single spec file
+npm run lint                      # ng lint (TSLint)
+npm run build-prod                # ng build --prod
+npm run e2e                       # Protractor e2e suite
+```
+
+## Architecture
+
+### fieldpicker: facade pattern over the Hippo plugin lifecycle
+
+The Wicket plugin never talks to your external system directly. Everything funnels through one interface you
+implement per document field / folder-workflow type:
+
+```java
+ExternalDocumentServiceFacade<T extends Serializable>
+    extends ExternalDocumentSearchService<T>, ExternalDocumentFieldService<T>,
+            ExternalDocumentDisplayService<T>, ExternalDocumentTreeService<T>, IClusterable
+```
+(`fieldpicker/.../api/ExternalDocumentServiceFacade.java`)
+
+- `ExternalDocumentSearchService.searchExternalDocuments(context, queryString)` — runs a search, returns an
+  `ExternalDocumentCollection<T>`.
+- `ExternalDocumentFieldService.getFieldExternalDocuments` / `setFieldExternalDocuments` — read/write the
+  currently-linked items on the CMS document node.
+- `ExternalDocumentDisplayService.getDocumentTitle` / `getDocumentDescription` / `getDocumentIconLink` (locale-aware)
+  and `isDocumentSelectable` — how a `T` renders in the picker dialog.
+- `ExternalDocumentTreeService.hasChildren` / `getChildren` / `getParent` (all default no-op) — implement these
+  only if the picker should render a **Tree List View** instead of the default **Flat List View**.
+- `ExternalDocumentCollection<T>` is a `Serializable`/`Cloneable` collection contract (Wicket state must be
+  serializable) — your `ExternalDocumentSearchService` implementation returns one of these.
+
+Every facade method receives an `ExternalDocumentServiceContext`, which exposes `getPlugin()`,
+`getPluginConfig()`, `getPluginContext()`, and `getContextModel()` (a `JcrNodeModel` for the document/folder
+currently open) plus a generic attribute bag — this is how facade code reaches back into Wicket/Hippo plugin
+machinery and the current JCR node.
+
+The concrete facade implementation class name is supplied as a Hippo plugin config parameter
+(`PluginConstants.PARAM_EXTERNAL_DOCUMENT_SERVICE_FACADE`); `PluginConstants` (`api/PluginConstants.java`) is the
+single source of truth for every other config parameter name/default (selection mode, dialog size, page size,
+initial search query, tree theme/expand depth, etc.) — check it before assuming a config key's name or default.
+
+Facades don't have to be instantiated directly: `ServiceDelegatingExternalDocumentServiceFacade`
+(`impl/ServiceDelegatingExternalDocumentServiceFacade.java`) implements the same interface but just looks up
+*another* facade registered as a Hippo plugin **service** (via `IPluginContext.getService(id, ...)`), keyed by
+the `delegate.external.document.service.id` config param — a way to point multiple field/folder plugin configs
+at one shared, centrally-registered facade instance instead of duplicating the implementation class per field.
+
+Plugin instantiation is tied to the CMS UI lifecycle: for `fieldpicker`, a facade instance is created when the
+matching document (or folder context menu) is opened and destroyed when it's closed — it is not a long-lived
+singleton.
+
+Implementation code (beyond the delegating facade) is split into `impl/field/` (document field plugin +
+list/tree dialog variants) and `impl/folder/` (folder context-menu plugin + list/tree variants), mirroring the
+two install targets described in `src/site/xdoc/field/architecture.xml` and `folder/architecture.xml`.
+
+### richtext-ckeditor: CKEditor 4 plugin
+
+Source is just two files: `plugins/exdocpickerbase/plugin.js` (registers the toolbar button/command) and
+`plugins/exdocpickerbase/dialogs/exdocbrowserdialog.js` (the picker dialog UI). There's no Java/Wicket layer here
+— it's a client-side CKEditor plugin bundled as CMS resources. A vendored CKEditor build lives only under
+`src/test/resources/ckeditor/` for the Jetty manual-test server; it is not part of the production artifact
+(production resources are copied to `target/classes/ckeditor/optimized` by the `create-optimized-resources`
+Maven execution).
+
+### openui-fieldpicker: Angular app as a Hippo OpenUI extension
+
+The CMS's built-in `OpenUiStringPlugin` loads this Angular app's `index.html` inside an iframe and drives it
+entirely through `@bloomreach/ui-extension`'s `UiExtension.register()` API — there is no server-side Java
+counterpart to this module beyond the built-in Hippo OpenUI plugin that hosts the iframe.
+
+- `CmsContextService` (`src/app/cms-context.service.ts`) is the single bridge to the host CMS: it registers the
+  UI extension, exposes `getUiScope()`, parses the extension's JSON config into a `PickerConfig`
+  (`src/app/picker-config.ts`), proxies `getFieldValue()`/`getFieldCompareValue()` to the CMS document field, and
+  injects the CMS's own theme CSS (`${uiScope.baseUrl}skin/hippo-cms/css/hippo-cms-theme.min.css`) into the
+  iframe document so the picker visually matches the host CMS.
+- `PickerConfig` (`findOneUrl`, `findAllUrl`, plus optional `showSearchInput`, `searchOnInit`, `initSearchTerm`,
+  `treeViewMode`, `initTreeExpandLevel`) is the entire contract between this generic Angular UI and a backend:
+  the app is backend-agnostic and driven purely by these two REST endpoint URLs configured per-field via the
+  Hippo namespace's `ui.extension.config`. The expected REST response shape is documented in
+  `src/site/xdoc/openui-field/spec-of-rest-services.xml` — implement your backend against that spec, not by
+  inspecting the Angular code.
+  - `treeViewMode` selects between the flat list dialog (`field-list-dialog/`) and tree dialog
+    (`field-tree-dialog/`), analogous to the Flat/Tree List View split in `fieldpicker`.
+- `AppComponent.ngOnInit()` sets the Angular `TranslateService` default language from `ui.locale` — i18n follows
+  the CMS session's locale, not the browser's.
+
+### demo module
+
+`demo/` (own reactor, parent `hippo-cms7-release`) assembles a runnable Hippo CMS instance wiring in all three
+pickers against an example REST data source. Run locally per `demo/README.txt`:
+
+```
+mvn clean verify
+mvn -P cargo.run                              # boots Essentials/CMS/site in Tomcat via Cargo
+mvn -P cargo.run,without-development-data     # skip bootstrapping demo repository content
+mvn -P cargo.run -Drepo.path=/path/to/repo     # persist the repo across `mvn clean` runs
+```
+CMS at `http://localhost:8080/cms`, Essentials setup at `http://localhost:8080/essentials`, site at
+`http://localhost:8080/exdocpickerbasedemo`, logs under `target/tomcat9x/logs`. Repository auto-export toggles
+from the CMS console (`/cms/console`); the default is controlled in
+`repository-data/application/src/main/resources/hcm-config/configuration/modules/autoexport-module.yaml`.
+Distribution tarballs: `mvn -P dist` or `mvn -P dist-with-development-data`.

--- a/demo/cms-dependencies/pom.xml
+++ b/demo/cms-dependencies/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.onehippo.forge.exdocpickerbase</groupId>
     <artifactId>exdocpickerbase-demo</artifactId>
-    <version>9.1.1-SNAPSHOT</version>
+    <version>10.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>exdocpickerbase-demo-cms-dependencies</artifactId>

--- a/demo/cms/pom.xml
+++ b/demo/cms/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.onehippo.forge.exdocpickerbase</groupId>
     <artifactId>exdocpickerbase-demo</artifactId>
-    <version>9.1.1-SNAPSHOT</version>
+    <version>10.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>exdocpickerbase-demo-cms</artifactId>

--- a/demo/cms/src/main/java/org/onehippo/forge/exdocpicker/demo/jpa/field/SimpleJPQLExternalDocumentServiceFacade.java
+++ b/demo/cms/src/main/java/org/onehippo/forge/exdocpicker/demo/jpa/field/SimpleJPQLExternalDocumentServiceFacade.java
@@ -24,10 +24,10 @@ import java.util.Locale;
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 import javax.jcr.Value;
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
-import javax.persistence.Persistence;
-import javax.persistence.Query;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.Persistence;
+import jakarta.persistence.Query;
 
 import org.apache.commons.beanutils.BeanUtils;
 import org.apache.commons.lang3.StringUtils;

--- a/demo/cms/src/main/java/org/onehippo/forge/exdocpicker/demo/jpa/model/Informant.java
+++ b/demo/cms/src/main/java/org/onehippo/forge/exdocpicker/demo/jpa/model/Informant.java
@@ -17,10 +17,10 @@ package org.onehippo.forge.exdocpicker.demo.jpa.model;
 
 import java.io.Serializable;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 
 @Entity
 @Table(name = "INFORMANT")

--- a/demo/cms/src/main/resources/META-INF/persistence.xml
+++ b/demo/cms/src/main/resources/META-INF/persistence.xml
@@ -10,8 +10,8 @@
   OR CONDITIONS OF ANY KIND, either express or implied. See the License for
   the specific language governing permissions and limitations under the License.
 -->
-<persistence xmlns="http://java.sun.com/xml/ns/persistence"
-             version="1.0">
+<persistence xmlns="http://xmlns.jcp.org/xml/ns/persistence"
+             version="2.2">
 
   <persistence-unit name="newsPU" transaction-type="RESOURCE_LOCAL">
     <provider>org.apache.openjpa.persistence.PersistenceProviderImpl</provider>

--- a/demo/essentials/pom.xml
+++ b/demo/essentials/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.onehippo.forge.exdocpickerbase</groupId>
     <artifactId>exdocpickerbase-demo</artifactId>
-    <version>9.1.1-SNAPSHOT</version>
+    <version>10.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>exdocpickerbase-demo-essentials</artifactId>

--- a/demo/hsqldb/pom.xml
+++ b/demo/hsqldb/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.forge.exdocpickerbase</groupId>
     <artifactId>exdocpickerbase-demo</artifactId>
-    <version>9.1.1-SNAPSHOT</version>
+    <version>10.0.0-SNAPSHOT</version>
   </parent>
 
   <name>Hippo CMS External Document Picker Base Demo Example HSQLDB</name>

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.cms7</groupId>
     <artifactId>hippo-cms7-release</artifactId>
-    <version>16.7.0</version>
+    <version>17.0.0</version>
     <relativePath></relativePath>
   </parent>
 
@@ -13,7 +13,7 @@
   <description>Hippo CMS External Document Picker Base Demo</description>
   <groupId>org.onehippo.forge.exdocpickerbase</groupId>
   <artifactId>exdocpickerbase-demo</artifactId>
-  <version>9.1.1-SNAPSHOT</version>
+  <version>10.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <!--
@@ -69,9 +69,9 @@
     <buildNumber>${maven.build.timestamp}</buildNumber>
 
     <!-- Project specific versions -->
-    <hsqldb.version>2.7.3</hsqldb.version>
+    <hsqldb.version>2.7.4</hsqldb.version>
     <jakarta.persistence-api.version>3.2.0</jakarta.persistence-api.version>
-    <openjpa.version>3.2.2</openjpa.version>
+    <openjpa.version>4.1.1</openjpa.version>
   </properties>
 
   <repositories>
@@ -175,7 +175,7 @@
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>${junit.version}</version>
+        <version>${junit4.version}</version>
         <scope>test</scope>
       </dependency>
 

--- a/demo/repository-data/application/pom.xml
+++ b/demo/repository-data/application/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.forge.exdocpickerbase</groupId>
     <artifactId>exdocpickerbase-demo-repository-data</artifactId>
-    <version>9.1.1-SNAPSHOT</version>
+    <version>10.0.0-SNAPSHOT</version>
   </parent>
 
   <name>Hippo CMS External Document Picker Base Demo Repository Data For Application</name>

--- a/demo/repository-data/development/pom.xml
+++ b/demo/repository-data/development/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.forge.exdocpickerbase</groupId>
     <artifactId>exdocpickerbase-demo-repository-data</artifactId>
-    <version>9.1.1-SNAPSHOT</version>
+    <version>10.0.0-SNAPSHOT</version>
   </parent>
 
   <name>Hippo CMS External Document Picker Base Demo Repository Data For Development</name>

--- a/demo/repository-data/pom.xml
+++ b/demo/repository-data/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.forge.exdocpickerbase</groupId>
     <artifactId>exdocpickerbase-demo</artifactId>
-    <version>9.1.1-SNAPSHOT</version>
+    <version>10.0.0-SNAPSHOT</version>
   </parent>
 
   <name>Hippo CMS External Document Picker Base Demo Repository Data</name>

--- a/demo/repository-data/site/pom.xml
+++ b/demo/repository-data/site/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.forge.exdocpickerbase</groupId>
     <artifactId>exdocpickerbase-demo-repository-data</artifactId>
-    <version>9.1.1-SNAPSHOT</version>
+    <version>10.0.0-SNAPSHOT</version>
   </parent>
 
   <name>Hippo CMS External Document Picker Base Demo Repository Data For Site</name>

--- a/demo/repository-data/webfiles/pom.xml
+++ b/demo/repository-data/webfiles/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.forge.exdocpickerbase</groupId>
     <artifactId>exdocpickerbase-demo-repository-data</artifactId>
-    <version>9.1.1-SNAPSHOT</version>
+    <version>10.0.0-SNAPSHOT</version>
   </parent>
 
   <name>Hippo CMS External Document Picker Base Demo Repository Data Web Files</name>

--- a/demo/site/components/pom.xml
+++ b/demo/site/components/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.forge.exdocpickerbase</groupId>
     <artifactId>exdocpickerbase-demo-site</artifactId>
-    <version>9.1.1-SNAPSHOT</version>
+    <version>10.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>exdocpickerbase-demo-components</artifactId>
   <packaging>jar</packaging>

--- a/demo/site/pom.xml
+++ b/demo/site/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.forge.exdocpickerbase</groupId>
     <artifactId>exdocpickerbase-demo</artifactId>
-    <version>9.1.1-SNAPSHOT</version>
+    <version>10.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>exdocpickerbase-demo-site</artifactId>

--- a/demo/site/webapp/pom.xml
+++ b/demo/site/webapp/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.onehippo.forge.exdocpickerbase</groupId>
     <artifactId>exdocpickerbase-demo-site</artifactId>
-    <version>9.1.1-SNAPSHOT</version>
+    <version>10.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>exdocpickerbase-demo-webapp</artifactId>
@@ -28,7 +28,7 @@
     <dependency>
       <groupId>org.onehippo.forge.exdocpickerbase</groupId>
       <artifactId>exdocpickerbase-demo-components</artifactId>
-      <version>9.1.1-SNAPSHOT</version>
+      <version>10.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.onehippo.cms7.hst.toolkit-resources.addon</groupId>

--- a/fieldpicker/pom.xml
+++ b/fieldpicker/pom.xml
@@ -116,6 +116,37 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.wicket</groupId>
+      <artifactId>wicket-tester</artifactId>
+      <version>10.8.0</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>
@@ -130,5 +161,41 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>coverage</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <argLine>@{argLine}</argLine>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>prepare-agent</id>
+                <goals>
+                  <goal>prepare-agent</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>report</id>
+                <phase>test</phase>
+                <goals>
+                  <goal>report</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
 </project>

--- a/fieldpicker/pom.xml
+++ b/fieldpicker/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.onehippo.forge.exdocpickerbase</groupId>
     <artifactId>exdocpickerbase</artifactId>
-    <version>9.1.1-SNAPSHOT</version>
+    <version>10.0.0-SNAPSHOT</version>
   </parent>
 
   <name>Hippo CMS External Document Picker Base for Field Picker</name>
@@ -105,12 +105,14 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <version>${junit4.version}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.easymock</groupId>
       <artifactId>easymock</artifactId>
+      <version>${easymock.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/fieldpicker/src/test/java/org/onehippo/forge/exdocpicker/api/ExternalDocumentDisplayServiceTest.java
+++ b/fieldpicker/src/test/java/org/onehippo/forge/exdocpicker/api/ExternalDocumentDisplayServiceTest.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2014-2026 Bloomreach B.V. (<a href="https://www.bloomreach.com">https://www.bloomreach.com</a>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         <a href="http://www.apache.org/licenses/LICENSE-2.0">http://www.apache.org/licenses/LICENSE-2.0</a>
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onehippo.forge.exdocpicker.api;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Locale;
+
+import org.junit.jupiter.api.Test;
+
+public class ExternalDocumentDisplayServiceTest {
+
+    private final ExternalDocumentDisplayService<String> defaultDisplayService = new ExternalDocumentDisplayService<String>() {
+
+        @Override
+        public String getDocumentTitle(ExternalDocumentServiceContext context, String doc, Locale preferredLocale) {
+            return null;
+        }
+
+        @Override
+        public String getDocumentDescription(ExternalDocumentServiceContext context, String doc,
+                Locale preferredLocale) {
+            return null;
+        }
+
+        @Override
+        public String getDocumentIconLink(ExternalDocumentServiceContext context, String doc,
+                Locale preferredLocale) {
+            return null;
+        }
+    };
+
+    @Test
+    public void isDocumentSelectable_defaultsToTrue() {
+        assertTrue(defaultDisplayService.isDocumentSelectable(null, "doc"));
+    }
+}

--- a/fieldpicker/src/test/java/org/onehippo/forge/exdocpicker/api/ExternalDocumentTreeServiceTest.java
+++ b/fieldpicker/src/test/java/org/onehippo/forge/exdocpicker/api/ExternalDocumentTreeServiceTest.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2014-2026 Bloomreach B.V. (<a href="https://www.bloomreach.com">https://www.bloomreach.com</a>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         <a href="http://www.apache.org/licenses/LICENSE-2.0">http://www.apache.org/licenses/LICENSE-2.0</a>
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onehippo.forge.exdocpicker.api;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.Iterator;
+
+import org.junit.jupiter.api.Test;
+
+public class ExternalDocumentTreeServiceTest {
+
+    private final ExternalDocumentTreeService<String> defaultTreeService = new ExternalDocumentTreeService<String>() {
+    };
+
+    @Test
+    public void hasChildren_defaultsToFalse() {
+        assertFalse(defaultTreeService.hasChildren("doc"));
+    }
+
+    @Test
+    public void getChildren_defaultsToEmptyIteratorNotNull() {
+        Iterator<String> children = defaultTreeService.getChildren("doc");
+
+        assertNotNull(children);
+        assertFalse(children.hasNext());
+    }
+
+    @Test
+    public void getParent_defaultsToNull() {
+        assertNull(defaultTreeService.getParent("doc"));
+    }
+}

--- a/fieldpicker/src/test/java/org/onehippo/forge/exdocpicker/impl/ServiceDelegatingExternalDocumentServiceFacadeTest.java
+++ b/fieldpicker/src/test/java/org/onehippo/forge/exdocpicker/impl/ServiceDelegatingExternalDocumentServiceFacadeTest.java
@@ -1,0 +1,174 @@
+/**
+ * Copyright 2014-2026 Bloomreach B.V. (<a href="https://www.bloomreach.com">https://www.bloomreach.com</a>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         <a href="http://www.apache.org/licenses/LICENSE-2.0">http://www.apache.org/licenses/LICENSE-2.0</a>
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onehippo.forge.exdocpicker.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.Serializable;
+import java.util.Locale;
+
+import org.hippoecm.frontend.plugin.IPluginContext;
+import org.hippoecm.frontend.plugin.config.IPluginConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.onehippo.forge.exdocpicker.api.ExternalDocumentCollection;
+import org.onehippo.forge.exdocpicker.api.ExternalDocumentServiceContext;
+import org.onehippo.forge.exdocpicker.api.ExternalDocumentServiceFacade;
+
+@ExtendWith(MockitoExtension.class)
+public class ServiceDelegatingExternalDocumentServiceFacadeTest {
+
+    private static final String SERVICE_ID = "delegateServiceId";
+
+    @Mock
+    private ExternalDocumentServiceContext context;
+
+    @Mock
+    private IPluginConfig pluginConfig;
+
+    @Mock
+    private IPluginContext pluginContext;
+
+    @Mock
+    private ExternalDocumentServiceFacade<Serializable> delegate;
+
+    private ServiceDelegatingExternalDocumentServiceFacade facade;
+
+    @BeforeEach
+    public void before() {
+        facade = new ServiceDelegatingExternalDocumentServiceFacade();
+    }
+
+    private void stubDelegateLookup() {
+        when(context.getPluginConfig()).thenReturn(pluginConfig);
+        when(pluginConfig.getString(ServiceDelegatingExternalDocumentServiceFacade.DELEGATE_EXTERNAL_DOCUMENT_SERVICE_ID))
+                .thenReturn(SERVICE_ID);
+        when(context.getPluginContext()).thenReturn(pluginContext);
+        when(pluginContext.getService(eq(SERVICE_ID), eq(ExternalDocumentServiceFacade.class))).thenReturn(delegate);
+    }
+
+    @Test
+    public void searchExternalDocuments_delegatesToLookedUpService() {
+        stubDelegateLookup();
+        @SuppressWarnings("unchecked")
+        ExternalDocumentCollection<Serializable> expected = mock(ExternalDocumentCollection.class);
+        when(delegate.searchExternalDocuments(context, "query")).thenReturn(expected);
+
+        ExternalDocumentCollection<Serializable> result = facade.searchExternalDocuments(context, "query");
+
+        assertSame(expected, result);
+        verify(delegate).searchExternalDocuments(context, "query");
+    }
+
+    @Test
+    public void getFieldExternalDocuments_delegatesToLookedUpService() {
+        stubDelegateLookup();
+        @SuppressWarnings("unchecked")
+        ExternalDocumentCollection<Serializable> expected = mock(ExternalDocumentCollection.class);
+        when(delegate.getFieldExternalDocuments(context)).thenReturn(expected);
+
+        ExternalDocumentCollection<Serializable> result = facade.getFieldExternalDocuments(context);
+
+        assertSame(expected, result);
+    }
+
+    @Test
+    public void setFieldExternalDocuments_delegatesToLookedUpService() {
+        stubDelegateLookup();
+        @SuppressWarnings("unchecked")
+        ExternalDocumentCollection<Serializable> exdocs = mock(ExternalDocumentCollection.class);
+
+        facade.setFieldExternalDocuments(context, exdocs);
+
+        verify(delegate).setFieldExternalDocuments(context, exdocs);
+    }
+
+    @Test
+    public void getDocumentTitle_delegatesToLookedUpService() {
+        stubDelegateLookup();
+        Serializable doc = "doc";
+        when(delegate.getDocumentTitle(context, doc, Locale.ENGLISH)).thenReturn("Title");
+
+        String title = facade.getDocumentTitle(context, doc, Locale.ENGLISH);
+
+        assertEquals("Title", title);
+    }
+
+    @Test
+    public void getDocumentDescription_delegatesToLookedUpService() {
+        stubDelegateLookup();
+        Serializable doc = "doc";
+        when(delegate.getDocumentDescription(context, doc, Locale.ENGLISH)).thenReturn("Description");
+
+        String description = facade.getDocumentDescription(context, doc, Locale.ENGLISH);
+
+        assertEquals("Description", description);
+    }
+
+    @Test
+    public void getDocumentIconLink_delegatesToLookedUpService() {
+        stubDelegateLookup();
+        Serializable doc = "doc";
+        when(delegate.getDocumentIconLink(context, doc, Locale.ENGLISH)).thenReturn("/icon.png");
+
+        String iconLink = facade.getDocumentIconLink(context, doc, Locale.ENGLISH);
+
+        assertEquals("/icon.png", iconLink);
+    }
+
+    @Test
+    public void serviceIdLookup_isCachedAfterFirstResolution_configReadOnlyOnce() {
+        stubDelegateLookup();
+        when(delegate.getFieldExternalDocuments(any())).thenReturn(null);
+
+        facade.getFieldExternalDocuments(context);
+        facade.searchExternalDocuments(context, "query");
+
+        verify(pluginConfig, times(1))
+                .getString(ServiceDelegatingExternalDocumentServiceFacade.DELEGATE_EXTERNAL_DOCUMENT_SERVICE_ID);
+    }
+
+    @Test
+    public void serviceIdLookup_nullConfigValue_throwsIllegalStateExceptionAndNeverLooksUpService() {
+        when(context.getPluginConfig()).thenReturn(pluginConfig);
+        when(pluginConfig.getString(ServiceDelegatingExternalDocumentServiceFacade.DELEGATE_EXTERNAL_DOCUMENT_SERVICE_ID))
+                .thenReturn(null);
+
+        assertThrows(IllegalStateException.class, () -> facade.getFieldExternalDocuments(context));
+        verify(pluginContext, never()).getService(any(), any());
+    }
+
+    @Test
+    public void serviceIdLookup_blankConfigValue_throwsIllegalStateException() {
+        when(context.getPluginConfig()).thenReturn(pluginConfig);
+        when(pluginConfig.getString(ServiceDelegatingExternalDocumentServiceFacade.DELEGATE_EXTERNAL_DOCUMENT_SERVICE_ID))
+                .thenReturn("   ");
+
+        assertThrows(IllegalStateException.class, () -> facade.getFieldExternalDocuments(context));
+    }
+}

--- a/fieldpicker/src/test/java/org/onehippo/forge/exdocpicker/impl/SimpleExternalDocumentCollectionDataProviderTest.java
+++ b/fieldpicker/src/test/java/org/onehippo/forge/exdocpicker/impl/SimpleExternalDocumentCollectionDataProviderTest.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2014-2026 Bloomreach B.V. (<a href="https://www.bloomreach.com">https://www.bloomreach.com</a>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         <a href="http://www.apache.org/licenses/LICENSE-2.0">http://www.apache.org/licenses/LICENSE-2.0</a>
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onehippo.forge.exdocpicker.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.when;
+
+import java.util.Iterator;
+
+import org.apache.wicket.model.IModel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.onehippo.forge.exdocpicker.api.ExternalDocumentCollection;
+
+@ExtendWith(MockitoExtension.class)
+public class SimpleExternalDocumentCollectionDataProviderTest {
+
+    @Mock
+    private ExternalDocumentCollection<DocumentObject> docCollection;
+
+    private SimpleExternalDocumentCollectionDataProvider<DocumentObject> dataProvider;
+
+    @BeforeEach
+    public void before() {
+        dataProvider = new SimpleExternalDocumentCollectionDataProvider<>(docCollection);
+    }
+
+    @Test
+    public void iterator_delegatesToCollectionWithFirstAndCount() {
+        @SuppressWarnings("unchecked")
+        Iterator<DocumentObject> expected = org.mockito.Mockito.mock(Iterator.class);
+        when(docCollection.iterator(2L, 5L)).thenReturn(expected);
+
+        Iterator<? extends DocumentObject> result = dataProvider.iterator(2L, 5L);
+
+        assertSame(expected, result);
+    }
+
+    @Test
+    public void size_delegatesToCollectionGetSize() {
+        when(docCollection.getSize()).thenReturn(42);
+
+        assertEquals(42L, dataProvider.size());
+    }
+
+    @Test
+    public void model_wrapsObjectInModel() {
+        DocumentObject doc = new DocumentObject();
+
+        IModel<DocumentObject> model = dataProvider.model(doc);
+
+        assertSame(doc, model.getObject());
+    }
+
+    @Test
+    public void detach_doesNotThrow() {
+        dataProvider.detach();
+    }
+}

--- a/fieldpicker/src/test/java/org/onehippo/forge/exdocpicker/impl/SimpleExternalDocumentCollectionTest.java
+++ b/fieldpicker/src/test/java/org/onehippo/forge/exdocpicker/impl/SimpleExternalDocumentCollectionTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014-2024 Bloomreach B.V. (<a href="https://www.bloomreach.com">https://www.bloomreach.com</a>)
+ * Copyright 2014-2026 Bloomreach B.V. (<a href="https://www.bloomreach.com">https://www.bloomreach.com</a>)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,26 +15,25 @@
  */
 package org.onehippo.forge.exdocpicker.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-/**
- *
- */
 public class SimpleExternalDocumentCollectionTest {
 
     private SimpleExternalDocumentCollection<DocumentObject> docCollection;
 
-    @Before
-    public void before() throws Exception {
-        docCollection = new SimpleExternalDocumentCollection<DocumentObject>();
+    @BeforeEach
+    public void before() {
+        docCollection = new SimpleExternalDocumentCollection<>();
 
         for (int i = 1; i <= 10; i++) {
             docCollection.add(createDoc(i, "Document " + i));
@@ -42,28 +41,33 @@ public class SimpleExternalDocumentCollectionTest {
     }
 
     @Test
-    public void testSize() throws Exception {
-        assertEquals(10, docCollection.getSize());
+    public void noArgConstructor_createsEmptyCollection() {
+        SimpleExternalDocumentCollection<DocumentObject> collection = new SimpleExternalDocumentCollection<>();
 
-        docCollection.remove(docCollection.iterator().next());
-        assertEquals(9, docCollection.getSize());
-
-        docCollection.add(createDoc(11, "Document 11"));
-        assertEquals(10, docCollection.getSize());
-
-        docCollection.add(createDoc(12, "Document 12"));
-        assertEquals(11, docCollection.getSize());
-
-        docCollection.addAll(Arrays.asList(createDoc(13, "Document 13"), createDoc(14, "Document 14"), createDoc(15, "Document 15")));
-        assertEquals(14, docCollection.getSize());
-
-        docCollection.clear();
-        assertEquals(0, docCollection.getSize());
+        assertEquals(0, collection.getSize());
     }
 
     @Test
-    public void testIteration() throws Exception {
-        Iterator<? extends DocumentObject> it = docCollection.iterator();
+    public void listConstructor_withNullSource_createsEmptyCollection() {
+        SimpleExternalDocumentCollection<DocumentObject> collection = new SimpleExternalDocumentCollection<>(null);
+
+        assertEquals(0, collection.getSize());
+    }
+
+    @Test
+    public void listConstructor_withSource_copiesEntries() {
+        List<DocumentObject> source = Arrays.asList(createDoc(1, "Document 1"), createDoc(2, "Document 2"));
+
+        SimpleExternalDocumentCollection<DocumentObject> collection = new SimpleExternalDocumentCollection<>(source);
+
+        assertEquals(2, collection.getSize());
+        assertTrue(collection.contains(source.get(0)));
+        assertTrue(collection.contains(source.get(1)));
+    }
+
+    @Test
+    public void iterator_returnsEntriesInInsertionOrder() {
+        Iterator<DocumentObject> it = docCollection.iterator();
 
         for (int i = 1; i <= 10; i++) {
             assertTrue(it.hasNext());
@@ -73,26 +77,152 @@ public class SimpleExternalDocumentCollectionTest {
         }
 
         assertFalse(it.hasNext());
+    }
 
-        it = docCollection.iterator(5, 4);
+    @Test
+    public void iteratorWithRange_offsetAndCount_returnsBoundedSubset() {
+        Iterator<DocumentObject> it = docCollection.iterator(5, 4);
 
         for (int i = 6; i <= 9; i++) {
             assertTrue(it.hasNext());
             DocumentObject item = it.next();
             assertEquals(i, item.getInt("id"));
-            assertEquals("Document " + i, item.getString("title"));
         }
 
         assertFalse(it.hasNext());
+    }
 
-        DocumentObject [] array = docCollection.toArray(new DocumentObject[docCollection.getSize()]);
+    @Test
+    public void iteratorWithRange_countExceedingRemainingEntries_stopsAtLastEntry() {
+        Iterator<DocumentObject> it = docCollection.iterator(8, 10);
+
+        int seen = 0;
+        while (it.hasNext()) {
+            it.next();
+            seen++;
+        }
+
+        assertEquals(2, seen);
+    }
+
+    @Test
+    public void iteratorWithRange_zeroCount_returnsNoEntries() {
+        Iterator<DocumentObject> it = docCollection.iterator(0, 0);
+
+        assertFalse(it.hasNext());
+    }
+
+    @Test
+    public void contains_existingEntry_returnsTrue() {
+        DocumentObject doc = docCollection.iterator().next();
+
+        assertTrue(docCollection.contains(doc));
+    }
+
+    @Test
+    public void contains_missingEntry_returnsFalse() {
+        DocumentObject doc = createDoc(99, "Missing");
+
+        assertFalse(docCollection.contains(doc));
+    }
+
+    @Test
+    public void indexOf_existingEntry_returnsItsPosition() {
+        DocumentObject doc = createDoc(20, "Document 20");
+        docCollection.add(doc);
+
+        assertEquals(10, docCollection.indexOf(doc));
+    }
+
+    @Test
+    public void indexOf_missingEntry_returnsNegativeOne() {
+        DocumentObject doc = createDoc(99, "Missing");
+
+        assertEquals(-1, docCollection.indexOf(doc));
+    }
+
+    @Test
+    public void add_appendsEntryAndIncreasesSize() {
+        DocumentObject doc = createDoc(11, "Document 11");
+
+        docCollection.add(doc);
+
+        assertEquals(11, docCollection.getSize());
+        assertEquals(10, docCollection.indexOf(doc));
+    }
+
+    @Test
+    public void addAtIndex_insertsEntryAtGivenPosition() {
+        DocumentObject doc = createDoc(0, "Document 0");
+
+        docCollection.add(0, doc);
+
+        assertEquals(11, docCollection.getSize());
+        assertEquals(0, docCollection.indexOf(doc));
+    }
+
+    @Test
+    public void addAll_appendsEveryEntryFromGivenCollection() {
+        List<DocumentObject> extra = Arrays.asList(createDoc(11, "Document 11"), createDoc(12, "Document 12"));
+
+        docCollection.addAll(extra);
+
+        assertEquals(12, docCollection.getSize());
+        assertTrue(docCollection.contains(extra.get(0)));
+        assertTrue(docCollection.contains(extra.get(1)));
+    }
+
+    @Test
+    public void remove_existingEntry_removesItAndDecreasesSize() {
+        DocumentObject doc = docCollection.iterator().next();
+
+        docCollection.remove(doc);
+
+        assertEquals(9, docCollection.getSize());
+        assertFalse(docCollection.contains(doc));
+    }
+
+    @Test
+    public void remove_missingEntry_leavesCollectionUnchanged() {
+        DocumentObject doc = createDoc(99, "Missing");
+
+        docCollection.remove(doc);
+
+        assertEquals(10, docCollection.getSize());
+    }
+
+    @Test
+    public void clear_removesAllEntries() {
+        docCollection.clear();
+
+        assertEquals(0, docCollection.getSize());
+    }
+
+    @Test
+    public void toArray_returnsEveryEntryInInsertionOrder() {
+        DocumentObject[] array = docCollection.toArray(new DocumentObject[docCollection.getSize()]);
+
         assertEquals(10, array.length);
 
         for (int i = 1; i <= 10; i++) {
-            DocumentObject item = array[i - 1];
-            assertEquals(i, item.getInt("id"));
-            assertEquals("Document " + i, item.getString("title"));
+            assertEquals(i, array[i - 1].getInt("id"));
         }
+    }
+
+    @Test
+    public void clone_returnsIndependentCollectionWithSameEntries() {
+        Object clone = docCollection.clone();
+
+        assertTrue(clone instanceof SimpleExternalDocumentCollection);
+
+        @SuppressWarnings("unchecked")
+        SimpleExternalDocumentCollection<DocumentObject> clonedCollection = (SimpleExternalDocumentCollection<DocumentObject>) clone;
+        assertNotSame(docCollection, clonedCollection);
+        assertEquals(docCollection.getSize(), clonedCollection.getSize());
+
+        DocumentObject doc = createDoc(11, "Document 11");
+        clonedCollection.add(doc);
+        assertFalse(docCollection.contains(doc));
     }
 
     private DocumentObject createDoc(int id, String title) {

--- a/fieldpicker/src/test/java/org/onehippo/forge/exdocpicker/impl/SimpleExternalDocumentServiceContextTest.java
+++ b/fieldpicker/src/test/java/org/onehippo/forge/exdocpicker/impl/SimpleExternalDocumentServiceContextTest.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright 2014-2026 Bloomreach B.V. (<a href="https://www.bloomreach.com">https://www.bloomreach.com</a>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         <a href="http://www.apache.org/licenses/LICENSE-2.0">http://www.apache.org/licenses/LICENSE-2.0</a>
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onehippo.forge.exdocpicker.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.Serializable;
+
+import org.hippoecm.frontend.model.JcrNodeModel;
+import org.hippoecm.frontend.plugin.IPlugin;
+import org.hippoecm.frontend.plugin.IPluginContext;
+import org.hippoecm.frontend.plugin.config.IPluginConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class SimpleExternalDocumentServiceContextTest {
+
+    @Mock
+    private IPlugin plugin;
+
+    @Mock
+    private IPluginConfig pluginConfig;
+
+    @Mock
+    private IPluginContext pluginContext;
+
+    @Mock
+    private JcrNodeModel contextModel;
+
+    private SimpleExternalDocumentServiceContext context;
+
+    @BeforeEach
+    public void before() {
+        context = new SimpleExternalDocumentServiceContext(plugin, pluginConfig, pluginContext, contextModel);
+    }
+
+    @Test
+    public void getPlugin_returnsConstructorArgument() {
+        assertSame(plugin, context.getPlugin());
+    }
+
+    @Test
+    public void getPluginConfig_returnsConstructorArgument() {
+        assertSame(pluginConfig, context.getPluginConfig());
+    }
+
+    @Test
+    public void getPluginContext_returnsConstructorArgument() {
+        assertSame(pluginContext, context.getPluginContext());
+    }
+
+    @Test
+    public void getContextModel_returnsConstructorArgument() {
+        assertSame(contextModel, context.getContextModel());
+    }
+
+    @Test
+    public void setAttribute_thenGetAttribute_returnsStoredValue() {
+        context.setAttribute("key", "value");
+
+        assertEquals("value", context.getAttribute("key"));
+    }
+
+    @Test
+    public void setAttribute_nullName_throwsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> context.setAttribute(null, "value"));
+    }
+
+    @Test
+    public void getAttribute_unknownName_returnsNull() {
+        assertNull(context.getAttribute("missing"));
+    }
+
+    @Test
+    public void removeAttribute_presentName_removesIt() {
+        context.setAttribute("key", "value");
+
+        context.removeAttribute("key");
+
+        assertNull(context.getAttribute("key"));
+        assertFalse(context.getAttributeNames().contains("key"));
+    }
+
+    @Test
+    public void getAttributeNames_reflectsStoredAttributes() {
+        context.setAttribute("key1", "value1");
+        context.setAttribute("key2", "value2");
+
+        assertEquals(2, context.getAttributeNames().size());
+        assertTrue(context.getAttributeNames().contains("key1"));
+        assertTrue(context.getAttributeNames().contains("key2"));
+    }
+
+    /**
+     * Documents existing (buggy) behavior: setAttribute(name, null) calls removeAttribute(name)
+     * but then unconditionally falls through to attributes.put(name, null), re-adding the key
+     * with a null value instead of leaving it removed. See SimpleExternalDocumentServiceContext
+     * lines 70-80 — flagged for triage, not fixed here per task scope.
+     */
+    @Test
+    public void setAttribute_withNullValue_reAddsKeyWithNullValueInsteadOfRemovingIt() {
+        context.setAttribute("key", "value");
+
+        context.setAttribute("key", (Serializable) null);
+
+        assertTrue(context.getAttributeNames().contains("key"));
+        assertNull(context.getAttribute("key"));
+    }
+}

--- a/fieldpicker/src/test/java/org/onehippo/forge/exdocpicker/impl/field/AbstractExternalDocumentFieldBrowserDialogTest.java
+++ b/fieldpicker/src/test/java/org/onehippo/forge/exdocpicker/impl/field/AbstractExternalDocumentFieldBrowserDialogTest.java
@@ -1,0 +1,173 @@
+package org.onehippo.forge.exdocpicker.impl.field;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.Serializable;
+import java.util.List;
+
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.Model;
+import org.apache.wicket.util.tester.WicketTester;
+import org.hippoecm.frontend.plugin.config.IPluginConfig;
+import org.hippoecm.frontend.plugin.config.impl.JavaPluginConfig;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.onehippo.forge.exdocpicker.api.ExternalDocumentCollection;
+import org.onehippo.forge.exdocpicker.api.ExternalDocumentServiceContext;
+import org.onehippo.forge.exdocpicker.api.ExternalDocumentServiceFacade;
+import org.onehippo.forge.exdocpicker.api.PluginConstants;
+import org.onehippo.forge.exdocpicker.impl.SimpleExternalDocumentCollection;
+
+public class AbstractExternalDocumentFieldBrowserDialogTest {
+
+    private WicketTester tester;
+
+    private ExternalDocumentServiceContext context;
+
+    private ExternalDocumentServiceFacade<Serializable> facade;
+
+    @AfterEach
+    public void after() {
+        if (tester != null) {
+            tester.destroy();
+        }
+    }
+
+    private AbstractExternalDocumentFieldBrowserDialog createDialog(IPluginConfig pluginConfig,
+            List<Serializable> initialSelectedDocs) {
+        tester = new WicketTester();
+
+        context = mock(ExternalDocumentServiceContext.class);
+        when(context.getPluginConfig()).thenReturn(pluginConfig);
+
+        @SuppressWarnings("unchecked")
+        final ExternalDocumentServiceFacade<Serializable> mockedFacade = mock(ExternalDocumentServiceFacade.class);
+        facade = mockedFacade;
+
+        final ExternalDocumentCollection<Serializable> selected = new SimpleExternalDocumentCollection<>(
+                initialSelectedDocs);
+        final IModel<ExternalDocumentCollection<Serializable>> model = Model.of(selected);
+
+        return new AbstractExternalDocumentFieldBrowserDialog(Model.of("Title"), context, facade, model) {
+            @Override
+            protected void initializeSearchedExternalDocuments() {
+            }
+
+            @Override
+            protected void initializeDataListView() {
+            }
+        };
+    }
+
+    @Test
+    public void isSingleSelectionMode_singleConfigValue_returnsTrue() {
+        final IPluginConfig pluginConfig = new JavaPluginConfig();
+        pluginConfig.put(PluginConstants.PARAM_SELECTION_MODE, "single");
+
+        final AbstractExternalDocumentFieldBrowserDialog dialog = createDialog(pluginConfig, List.of());
+
+        assertTrue(dialog.isSingleSelectionMode());
+    }
+
+    @Test
+    public void isSingleSelectionMode_singleConfigValueMixedCase_returnsTrue() {
+        final IPluginConfig pluginConfig = new JavaPluginConfig();
+        pluginConfig.put(PluginConstants.PARAM_SELECTION_MODE, "SiNgLe");
+
+        final AbstractExternalDocumentFieldBrowserDialog dialog = createDialog(pluginConfig, List.of());
+
+        assertTrue(dialog.isSingleSelectionMode());
+    }
+
+    @Test
+    public void isSingleSelectionMode_multipleConfigValue_returnsFalse() {
+        final IPluginConfig pluginConfig = new JavaPluginConfig();
+        pluginConfig.put(PluginConstants.PARAM_SELECTION_MODE, PluginConstants.SELECTION_MODE_MULTIPLE);
+
+        final AbstractExternalDocumentFieldBrowserDialog dialog = createDialog(pluginConfig, List.of());
+
+        assertFalse(dialog.isSingleSelectionMode());
+    }
+
+    @Test
+    public void isSingleSelectionMode_unsetConfig_defaultsToMultiple() {
+        final IPluginConfig pluginConfig = new JavaPluginConfig();
+
+        final AbstractExternalDocumentFieldBrowserDialog dialog = createDialog(pluginConfig, List.of());
+
+        assertFalse(dialog.isSingleSelectionMode());
+    }
+
+    @Test
+    public void onOk_singleSelectionMode_keepsOnlyLastPickedItem() {
+        final IPluginConfig pluginConfig = new JavaPluginConfig();
+        pluginConfig.put(PluginConstants.PARAM_SELECTION_MODE, PluginConstants.SELECTION_MODE_SINGLE);
+
+        final AbstractExternalDocumentFieldBrowserDialog dialog = createDialog(pluginConfig, List.of("doc1"));
+
+        dialog.getPickedExternalDocuments().clear();
+        dialog.getPickedExternalDocuments().add("doc1");
+        dialog.getPickedExternalDocuments().add("doc2");
+        dialog.getPickedExternalDocuments().add("doc3");
+
+        dialog.onOk();
+
+        final ExternalDocumentCollection<Serializable> selected = dialog.getSelectedExternalDocuments();
+        assertEquals(1, selected.getSize());
+        assertTrue(selected.contains("doc3"));
+        verify(facade).setFieldExternalDocuments(context, selected);
+    }
+
+    @Test
+    public void onOk_singleSelectionMode_nothingPicked_clearsSelectionAndStillNotifiesFacade() {
+        final IPluginConfig pluginConfig = new JavaPluginConfig();
+        pluginConfig.put(PluginConstants.PARAM_SELECTION_MODE, PluginConstants.SELECTION_MODE_SINGLE);
+
+        final AbstractExternalDocumentFieldBrowserDialog dialog = createDialog(pluginConfig, List.of("doc1"));
+
+        dialog.getPickedExternalDocuments().clear();
+
+        dialog.onOk();
+
+        final ExternalDocumentCollection<Serializable> selected = dialog.getSelectedExternalDocuments();
+        assertEquals(0, selected.getSize());
+        verify(facade).setFieldExternalDocuments(context, selected);
+    }
+
+    @Test
+    public void onOk_multiSelectionMode_addsOnlyNewPickedItems() {
+        final IPluginConfig pluginConfig = new JavaPluginConfig();
+        pluginConfig.put(PluginConstants.PARAM_SELECTION_MODE, PluginConstants.SELECTION_MODE_MULTIPLE);
+
+        final AbstractExternalDocumentFieldBrowserDialog dialog = createDialog(pluginConfig, List.of("doc1"));
+
+        dialog.getPickedExternalDocuments().add("doc2");
+
+        dialog.onOk();
+
+        final ExternalDocumentCollection<Serializable> selected = dialog.getSelectedExternalDocuments();
+        assertEquals(2, selected.getSize());
+        assertTrue(selected.contains("doc1"));
+        assertTrue(selected.contains("doc2"));
+        verify(facade).setFieldExternalDocuments(context, selected);
+    }
+
+    @Test
+    public void onOk_multiSelectionMode_noNewItemsPicked_doesNotNotifyFacade() {
+        final IPluginConfig pluginConfig = new JavaPluginConfig();
+        pluginConfig.put(PluginConstants.PARAM_SELECTION_MODE, PluginConstants.SELECTION_MODE_MULTIPLE);
+
+        final AbstractExternalDocumentFieldBrowserDialog dialog = createDialog(pluginConfig, List.of("doc1"));
+
+        dialog.onOk();
+
+        assertEquals(1, dialog.getSelectedExternalDocuments().getSize());
+        verifyNoInteractions(facade);
+    }
+}

--- a/fieldpicker/src/test/java/org/onehippo/forge/exdocpicker/impl/field/tree/ExternalTreeItemDataProviderTest.java
+++ b/fieldpicker/src/test/java/org/onehippo/forge/exdocpicker/impl/field/tree/ExternalTreeItemDataProviderTest.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright 2014-2026 Bloomreach B.V. (<a href="https://www.bloomreach.com">https://www.bloomreach.com</a>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         <a href="http://www.apache.org/licenses/LICENSE-2.0">http://www.apache.org/licenses/LICENSE-2.0</a>
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onehippo.forge.exdocpicker.impl.field.tree;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Iterator;
+
+import org.apache.wicket.model.IModel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.onehippo.forge.exdocpicker.api.ExternalDocumentCollection;
+import org.onehippo.forge.exdocpicker.api.ExternalDocumentTreeService;
+
+@ExtendWith(MockitoExtension.class)
+public class ExternalTreeItemDataProviderTest {
+
+    @Mock
+    private ExternalDocumentCollection<String> rootTreeItems;
+
+    @Mock
+    private ExternalDocumentTreeService<String> treeService;
+
+    private ExternalTreeItemDataProvider<String> dataProvider;
+
+    @BeforeEach
+    public void before() {
+        dataProvider = new ExternalTreeItemDataProvider<>(rootTreeItems, treeService);
+    }
+
+    @Test
+    public void getRoots_delegatesToRootTreeItemsIterator() {
+        @SuppressWarnings("unchecked")
+        Iterator<String> expected = mock(Iterator.class);
+        when(rootTreeItems.iterator()).thenReturn(expected);
+
+        Iterator<? extends String> result = dataProvider.getRoots();
+
+        assertSame(expected, result);
+    }
+
+    @Test
+    public void hasChildren_delegatesToTreeService() {
+        when(treeService.hasChildren("item")).thenReturn(true);
+
+        assertTrue(dataProvider.hasChildren("item"));
+    }
+
+    @Test
+    public void getChildren_delegatesToTreeService() {
+        @SuppressWarnings("unchecked")
+        Iterator<String> expected = mock(Iterator.class);
+        when(treeService.getChildren("item")).thenReturn(expected);
+
+        Iterator<String> result = dataProvider.getChildren("item");
+
+        assertSame(expected, result);
+    }
+
+    @Test
+    public void getParent_delegatesToTreeService() {
+        when(treeService.getParent("item")).thenReturn("parent");
+
+        assertEquals("parent", dataProvider.getParent("item"));
+    }
+
+    @Test
+    public void model_wrapsItemInModel() {
+        IModel<String> model = dataProvider.model("item");
+
+        assertEquals("item", model.getObject());
+    }
+
+    @Test
+    public void detach_doesNotThrow() {
+        dataProvider.detach();
+    }
+}

--- a/fieldpicker/src/test/java/org/onehippo/forge/exdocpicker/impl/field/tree/TreeItemExpansionSetTest.java
+++ b/fieldpicker/src/test/java/org/onehippo/forge/exdocpicker/impl/field/tree/TreeItemExpansionSetTest.java
@@ -1,0 +1,187 @@
+/**
+ * Copyright 2014-2026 Bloomreach B.V. (<a href="https://www.bloomreach.com">https://www.bloomreach.com</a>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         <a href="http://www.apache.org/licenses/LICENSE-2.0">http://www.apache.org/licenses/LICENSE-2.0</a>
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onehippo.forge.exdocpicker.impl.field.tree;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class TreeItemExpansionSetTest {
+
+    private static final String ITEM = "item-1";
+
+    private TreeItemExpansionSet expansionSet;
+
+    @BeforeEach
+    public void before() {
+        expansionSet = new TreeItemExpansionSet();
+    }
+
+    @Test
+    public void newSet_notInversedByDefault_containsReturnsFalseForAnyItem() {
+        assertFalse(expansionSet.contains(ITEM));
+    }
+
+    @Test
+    public void add_whenNotInversed_addsItemAndMakesItContained() {
+        boolean added = expansionSet.add(ITEM);
+
+        assertTrue(added);
+        assertTrue(expansionSet.contains(ITEM));
+    }
+
+    @Test
+    public void add_whenNotInversed_duplicateItem_returnsFalse() {
+        expansionSet.add(ITEM);
+
+        boolean addedAgain = expansionSet.add(ITEM);
+
+        assertFalse(addedAgain);
+    }
+
+    @Test
+    public void remove_whenNotInversed_presentItem_removesItAndReturnsTrue() {
+        expansionSet.add(ITEM);
+
+        boolean removed = expansionSet.remove(ITEM);
+
+        assertTrue(removed);
+        assertFalse(expansionSet.contains(ITEM));
+    }
+
+    @Test
+    public void remove_whenNotInversed_absentItem_returnsFalse() {
+        boolean removed = expansionSet.remove(ITEM);
+
+        assertFalse(removed);
+    }
+
+    @Test
+    public void expandAll_setsInversedAndClearsItems_soEveryItemIsContained() {
+        expansionSet.add(ITEM);
+
+        expansionSet.expandAll();
+
+        assertTrue(expansionSet.contains(ITEM));
+        assertTrue(expansionSet.contains("any-other-item"));
+    }
+
+    @Test
+    public void collapseAll_clearsItemsAndUninverts_soNoItemIsContained() {
+        expansionSet.expandAll();
+
+        expansionSet.collapseAll();
+
+        assertFalse(expansionSet.contains(ITEM));
+        assertFalse(expansionSet.contains("any-other-item"));
+    }
+
+    @Test
+    public void add_whenInversed_itemNotYetExcepted_returnsFalseAndLeavesItContained() {
+        expansionSet.expandAll();
+
+        boolean added = expansionSet.add(ITEM);
+
+        assertFalse(added);
+        assertTrue(expansionSet.contains(ITEM));
+    }
+
+    @Test
+    public void remove_whenInversed_marksItemAsExceptionAndReturnsTrue() {
+        expansionSet.expandAll();
+
+        boolean removed = expansionSet.remove(ITEM);
+
+        assertTrue(removed);
+        assertFalse(expansionSet.contains(ITEM));
+    }
+
+    @Test
+    public void remove_whenInversed_duplicateException_returnsFalse() {
+        expansionSet.expandAll();
+        expansionSet.remove(ITEM);
+
+        boolean removedAgain = expansionSet.remove(ITEM);
+
+        assertFalse(removedAgain);
+    }
+
+    @Test
+    public void add_whenInversed_reAddsPreviouslyExceptedItem_returnsTrueAndRestoresContainment() {
+        expansionSet.expandAll();
+        expansionSet.remove(ITEM);
+
+        boolean added = expansionSet.add(ITEM);
+
+        assertTrue(added);
+        assertTrue(expansionSet.contains(ITEM));
+    }
+
+    @Test
+    public void clear_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, () -> expansionSet.clear());
+    }
+
+    @Test
+    public void size_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, () -> expansionSet.size());
+    }
+
+    @Test
+    public void isEmpty_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, () -> expansionSet.isEmpty());
+    }
+
+    @Test
+    public void toArrayWithArgument_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, () -> expansionSet.toArray(new Object[0]));
+    }
+
+    @Test
+    public void toArray_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, () -> expansionSet.toArray());
+    }
+
+    @Test
+    public void iterator_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, () -> expansionSet.iterator());
+    }
+
+    @Test
+    public void containsAll_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, () -> expansionSet.containsAll(Collections.emptyList()));
+    }
+
+    @Test
+    public void addAll_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, () -> expansionSet.addAll(Collections.emptyList()));
+    }
+
+    @Test
+    public void retainAll_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, () -> expansionSet.retainAll(Collections.emptyList()));
+    }
+
+    @Test
+    public void removeAll_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, () -> expansionSet.removeAll(Collections.emptyList()));
+    }
+}

--- a/openui-fieldpicker/pom.xml
+++ b/openui-fieldpicker/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.onehippo.forge.exdocpickerbase</groupId>
     <artifactId>exdocpickerbase</artifactId>
-    <version>9.1.1-SNAPSHOT</version>
+    <version>10.0.0-SNAPSHOT</version>
   </parent>
 
   <name>Hippo CMS External Document Picker Base for OpenUI Field Picker</name>

--- a/pom.xml
+++ b/pom.xml
@@ -16,32 +16,28 @@
   <parent>
     <groupId>org.onehippo.cms7</groupId>
     <artifactId>hippo-cms7-project</artifactId>
-    <version>16.7.0</version>
+    <version>17.0.0</version>
   </parent>
 
   <name>Hippo CMS External Document Picker Base</name>
   <description>Hippo CMS External Document Picker Base</description>
   <groupId>org.onehippo.forge.exdocpickerbase</groupId>
   <artifactId>exdocpickerbase</artifactId>
-  <version>9.1.1-SNAPSHOT</version>
+  <version>10.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <url>https://github.com/bloomreach-forge/external-document-picker/</url>
 
   <properties>
-    <project.build.javaVersion>17</project.build.javaVersion>
+    <project.build.javaVersion>21</project.build.javaVersion>
 
     <extension.wagon-svn.version>1.9</extension.wagon-svn.version>
 
-    <!-- test dependencies -->
-    <lib.junit.version>4.13.1</lib.junit.version>
-    <lib.easymock.version>3.4</lib.easymock.version>
-
     <!-- no version in parent  -->
-    <plugin.jxr.version>3.5.0</plugin.jxr.version>
-    <plugin.pmd.version>3.1</plugin.pmd.version>
+    <plugin.jxr.version>3.6.0</plugin.jxr.version>
+    <plugin.pmd.version>3.28.0</plugin.pmd.version>
 
     <!-- parent version is lower currently, change if it gets higher   -->
-    <plugin.frontend-maven-plugin.version>1.12.1</plugin.frontend-maven-plugin.version>
+    <plugin.frontend-maven-plugin.version>2.0.1</plugin.frontend-maven-plugin.version>
   </properties>
 
   <licenses>
@@ -83,7 +79,7 @@
   </distributionManagement>
 
   <issueManagement>
-    <url>https://issues.onehippo.com/projects/HIPFORGE</url>
+    <url>https://bloomreach.atlassian.net/browse/FORGE</url>
   </issueManagement>
 
   <repositories>

--- a/richtext-ckeditor/pom.xml
+++ b/richtext-ckeditor/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.onehippo.forge.exdocpickerbase</groupId>
     <artifactId>exdocpickerbase</artifactId>
-    <version>9.1.1-SNAPSHOT</version>
+    <version>10.0.0-SNAPSHOT</version>
   </parent>
 
   <name>Hippo CMS External Document Picker Base for RichText Field in CKEditor</name>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -19,7 +19,7 @@
   <skin>
     <groupId>org.bloomreach.forge.mavenskin</groupId>
     <artifactId>forge-maven-skin</artifactId>
-    <version>3.2.1</version>
+    <version>3.2.2</version>
   </skin>
 
   <custom>

--- a/src/site/xdoc/field/architecture.xml
+++ b/src/site/xdoc/field/architecture.xml
@@ -25,9 +25,9 @@
     <section name="Architecture (External Document Field Picker)">
       <subsection name="Overview">
         <p>
-          In Hippo CMS authoring application, the <strong>External Document Picker Base for Field Picker</strong>
+          In the brXM authoring application, the <strong>External Document Picker Base for Field Picker</strong>
           plugin and <strong>External Picker Folder Context Menu</strong> plugins are installed.
-          Then you can configure field(s) in document template bootstrap files (a.k.a Hippo CMS 'namespace'),
+          Then you can configure field(s) in document template bootstrap files (a.k.a brXM 'namespace'),
           or you can configure folder workflow configurations for a custom folder context menu item.
           So, when you are editing a document or working on a folder in CMS authoring application,
           you will see those being displayed by this plugin.

--- a/src/site/xdoc/index.xml
+++ b/src/site/xdoc/index.xml
@@ -19,13 +19,13 @@
 -->
 <document>
   <properties>
-    <title>Hippo CMS External Document Picker Base</title>
+    <title>brXM External Document Picker Base</title>
   </properties>
   <body>
-    <section name="Hippo CMS External Document Picker Base">
+    <section name="brXM External Document Picker Base">
       <p>
         This project provides base external document picker Wicket plugins and OpenUI Extension based plugins
-        for Hippo CMS with simple example implementations for developer's references.
+        for brXM with simple example implementations for developer's references.
       </p>
       <p>
         This project contains various external document pickers for different use cases:

--- a/src/site/xdoc/openui-field/architecture.xml
+++ b/src/site/xdoc/openui-field/architecture.xml
@@ -30,9 +30,9 @@
 
       <subsection name="Overview">
         <p>
-          In Hippo CMS authoring application, the <strong>OpenUI External Document Picker Base for Field Picker</strong>
+          In the brXM authoring application, the <strong>OpenUI External Document Picker Base for Field Picker</strong>
           plugin is installed.
-          Then you can configure field(s) in document template bootstrap files (a.k.a Hippo CMS 'namespace').
+          Then you can configure field(s) in document template bootstrap files (a.k.a brXM 'namespace').
           So, when you are editing a document in CMS authoring application,
           you will see those being displayed by this plugin.
         </p>

--- a/src/site/xdoc/release-notes.xml
+++ b/src/site/xdoc/release-notes.xml
@@ -30,6 +30,10 @@
           <th>Hippo CMS Release version</th>
         </tr>
         <tr>
+          <td>10.x</td>
+          <td>17.x+</td>
+        </tr>
+        <tr>
           <td>9.1.x</td>
           <td>16.7.x+</td>
         </tr>
@@ -72,6 +76,11 @@
       </table>
     </section>
     <section name="Release Notes">
+      <subsection name="10.0.0">
+        <ul>
+          <li>FORGE-589 - Upgrade for XM 17.0.0 compatibility.</li>
+        </ul>
+      </subsection>
       <subsection name="9.1.0">
         <p class="smallinfo">Released: 21 July 2026</p>
         <ul>

--- a/src/site/xdoc/richtext-ckeditor/architecture.xml
+++ b/src/site/xdoc/richtext-ckeditor/architecture.xml
@@ -25,8 +25,8 @@
     <section name="Architecture (External Link Picker Button in the RichText Editor)">
       <subsection name="Overview">
         <p>
-          In Hippo CMS UI, the <strong>External Document Picker Base for RichText Field in CKEditor</strong> plugin is installed.
-          Then you can configure a RichText (HTML) field(s) in bootstrap XML files (a.k.a Hippo CMS 'namespace').
+          In the brXM UI, the <strong>External Document Picker Base for RichText Field in CKEditor</strong> plugin is installed.
+          Then you can configure a RichText (HTML) field(s) in bootstrap XML files (a.k.a brXM 'namespace').
           So, when you are editing a document in CMS UI, you will see a button handled by this CKEditor plugin
           to select an external document in the RichText (HTML) editor field.
         </p>


### PR DESCRIPTION
- Upgrade project to run on Experience Manager 17.0.0 (JDK 21, Spring Boot 4). 
- Parent POMs bumped from 16.0.0 to 17.0.0; project version advanced to 10.0.0-SNAPSHOT
- Java compile target raised from 17 to 21. v17
- OpenJPA upgraded for Java 21 bytecode support with javax.persistence→jakarta.persistence import migration and persistence.xml updated to JPA 2.2 namespace. 
- Issue tracker URL updated from issues.onehippo.com to bloomreach.atlassian.net.