### PR TITLE
FORGE-671: upgrade to 16.7.0+

### DIFF
--- a/demo/cms-dependencies/pom.xml
+++ b/demo/cms-dependencies/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.onehippo.forge.exdocpickerbase</groupId>
     <artifactId>exdocpickerbase-demo</artifactId>
-    <version>9.0.1-SNAPSHOT</version>
+    <version>9.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>exdocpickerbase-demo-cms-dependencies</artifactId>
@@ -24,12 +24,6 @@
     <dependency>
       <groupId>org.onehippo.forge.exdocpickerbase</groupId>
       <artifactId>exdocpickerbase-field</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>net.sf.json-lib</groupId>
-      <artifactId>json-lib</artifactId>
-      <classifier>jdk15</classifier>
     </dependency>
 
     <dependency>

--- a/demo/cms/pom.xml
+++ b/demo/cms/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.onehippo.forge.exdocpickerbase</groupId>
     <artifactId>exdocpickerbase-demo</artifactId>
-    <version>9.0.1-SNAPSHOT</version>
+    <version>9.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>exdocpickerbase-demo-cms</artifactId>

--- a/demo/cms/src/main/java/org/onehippo/forge/exdocpicker/demo/field/DocumentObject.java
+++ b/demo/cms/src/main/java/org/onehippo/forge/exdocpicker/demo/field/DocumentObject.java
@@ -1,0 +1,11 @@
+package org.onehippo.forge.exdocpicker.demo.field;
+
+import org.json.JSONObject;
+
+import java.io.Serializable;
+
+/**
+ * Object representing the document, extended from JSONObject to support serialization.
+ */
+public class DocumentObject extends JSONObject implements Serializable {
+}

--- a/demo/cms/src/main/java/org/onehippo/forge/exdocpicker/demo/field/ExampleExternalDocumentServiceFacade.java
+++ b/demo/cms/src/main/java/org/onehippo/forge/exdocpicker/demo/field/ExampleExternalDocumentServiceFacade.java
@@ -27,8 +27,10 @@ import javax.jcr.RepositoryException;
 import javax.jcr.Value;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.hippoecm.repository.HippoStdNodeType;
+import org.json.JSONArray;
+import org.json.JSONObject;
 import org.onehippo.forge.exdocpicker.api.ExternalDocumentCollection;
 import org.onehippo.forge.exdocpicker.api.ExternalDocumentServiceContext;
 import org.onehippo.forge.exdocpicker.api.ExternalDocumentServiceFacade;
@@ -36,15 +38,11 @@ import org.onehippo.forge.exdocpicker.impl.SimpleExternalDocumentCollection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import net.sf.json.JSONArray;
-import net.sf.json.JSONObject;
-import net.sf.json.JSONSerializer;
-
 /**
  * Example trivial implementation of <code>ExternalDocumentServiceFacade</code> for developer's reference.
  *
  * <P>
- * This example simply reads all the document data as <code>JSONArray</code> containing multiple <code>JSONObject</code> instances.
+ * This example simply reads all the document data as <code>JSONArray</code> containing multiple <code>DocumentObject</code> instances.
  * from <code>classpath:org/onehippo/forge/exdocpicker/demo/field/ExampleExternalDocumentServiceFacade.json</code>.
  * </p>
  * <p>
@@ -56,7 +54,7 @@ import net.sf.json.JSONSerializer;
  * to get the physical field name of the document node.
  * </p>
  */
-public class ExampleExternalDocumentServiceFacade implements ExternalDocumentServiceFacade<JSONObject> {
+public class ExampleExternalDocumentServiceFacade implements ExternalDocumentServiceFacade<DocumentObject> {
 
     /**
      * Plugin parameter name for physical document field name (JCR property name).
@@ -72,25 +70,39 @@ public class ExampleExternalDocumentServiceFacade implements ExternalDocumentSer
     public ExampleExternalDocumentServiceFacade() {
         try(InputStream input = ExampleExternalDocumentServiceFacade.class
                 .getResourceAsStream(ExampleExternalDocumentServiceFacade.class.getSimpleName() + ".json");) {
-            docArray = (JSONArray) JSONSerializer.toJSON(IOUtils.toString(input, StandardCharsets.UTF_8));
+            String json = new String(input.readAllBytes(), StandardCharsets.UTF_8);
+            JSONArray parsedArray = new JSONArray(json);
+            docArray = new JSONArray();
+
+            for (int i = 0; i < parsedArray.length(); i++) {
+                JSONObject jsonObject = parsedArray.getJSONObject(i);
+
+                DocumentObject documentObject = new DocumentObject();
+                for (String key : jsonObject.keySet()) {
+                    documentObject.put(key, jsonObject.get(key));
+                }
+
+                docArray.put(documentObject);
+            }
+
         } catch (Exception e) {
             log.error("Failed to load JSON data.", e);
         }
     }
 
     @Override
-    public ExternalDocumentCollection<JSONObject> searchExternalDocuments(ExternalDocumentServiceContext context,
+    public ExternalDocumentCollection<DocumentObject> searchExternalDocuments(ExternalDocumentServiceContext context,
             String queryString) {
-        ExternalDocumentCollection<JSONObject> docCollection = new SimpleExternalDocumentCollection<>();
-        int size = docArray.size();
+        ExternalDocumentCollection<DocumentObject> docCollection = new SimpleExternalDocumentCollection<>();
+        int size = docArray.length();
 
         if (StringUtils.isBlank(queryString)) {
             for (int i = 0; i < size; i++) {
-                docCollection.add(docArray.getJSONObject(i));
+                docCollection.add((DocumentObject) docArray.get(i));
             }
         } else {
             for (int i = 0; i < size; i++) {
-                JSONObject doc = docArray.getJSONObject(i);
+                DocumentObject doc = (DocumentObject) docArray.get(i);
 
                 if (StringUtils.contains(doc.toString(), queryString)) {
                     docCollection.add(doc);
@@ -102,7 +114,7 @@ public class ExampleExternalDocumentServiceFacade implements ExternalDocumentSer
     }
 
     @Override
-    public ExternalDocumentCollection<JSONObject> getFieldExternalDocuments(ExternalDocumentServiceContext context) {
+    public ExternalDocumentCollection<DocumentObject> getFieldExternalDocuments(ExternalDocumentServiceContext context) {
         final String fieldName = context.getPluginConfig().getString(PARAM_EXTERNAL_DOCS_FIELD_NAME);
 
         if (StringUtils.isBlank(fieldName)) {
@@ -110,7 +122,7 @@ public class ExampleExternalDocumentServiceFacade implements ExternalDocumentSer
                     + PARAM_EXTERNAL_DOCS_FIELD_NAME + "': " + fieldName);
         }
 
-        ExternalDocumentCollection<JSONObject> docCollection = new SimpleExternalDocumentCollection<>();
+        ExternalDocumentCollection<DocumentObject> docCollection = new SimpleExternalDocumentCollection<>();
 
         try {
             final Node contextNode = context.getContextModel().getNode();
@@ -120,7 +132,7 @@ public class ExampleExternalDocumentServiceFacade implements ExternalDocumentSer
 
                 for (Value value : values) {
                     String id = value.getString();
-                    JSONObject doc = findDocumentById(id);
+                    DocumentObject doc = findDocumentById(id);
                     docCollection.add(doc);
                 }
             }
@@ -133,7 +145,7 @@ public class ExampleExternalDocumentServiceFacade implements ExternalDocumentSer
 
     @Override
     public void setFieldExternalDocuments(ExternalDocumentServiceContext context,
-            ExternalDocumentCollection<JSONObject> exdocs) {
+            ExternalDocumentCollection<DocumentObject> exdocs) {
         final String fieldName = context.getPluginConfig().getString(PARAM_EXTERNAL_DOCS_FIELD_NAME);
 
         if (StringUtils.isBlank(fieldName)) {
@@ -145,8 +157,8 @@ public class ExampleExternalDocumentServiceFacade implements ExternalDocumentSer
             final Node contextNode = context.getContextModel().getNode();
             final List<String> docIds = new ArrayList<>();
 
-            for (Iterator<? extends JSONObject> it = exdocs.iterator(); it.hasNext();) {
-                JSONObject doc = it.next();
+            for (Iterator<? extends DocumentObject> it = exdocs.iterator(); it.hasNext();) {
+                DocumentObject doc = it.next();
                 docIds.add(doc.getString("id"));
             }
 
@@ -161,7 +173,7 @@ public class ExampleExternalDocumentServiceFacade implements ExternalDocumentSer
     }
 
     @Override
-    public String getDocumentTitle(ExternalDocumentServiceContext context, JSONObject doc, Locale preferredLocale) {
+    public String getDocumentTitle(ExternalDocumentServiceContext context, DocumentObject doc, Locale preferredLocale) {
         if (doc != null && doc.has("title")) {
             return doc.getString("title");
         }
@@ -170,7 +182,7 @@ public class ExampleExternalDocumentServiceFacade implements ExternalDocumentSer
     }
 
     @Override
-    public String getDocumentDescription(ExternalDocumentServiceContext context, JSONObject doc,
+    public String getDocumentDescription(ExternalDocumentServiceContext context, DocumentObject doc,
             Locale preferredLocale) {
         if (doc != null && doc.has("description")) {
             return doc.getString("description");
@@ -180,7 +192,7 @@ public class ExampleExternalDocumentServiceFacade implements ExternalDocumentSer
     }
 
     @Override
-    public String getDocumentIconLink(ExternalDocumentServiceContext context, JSONObject doc, Locale preferredLocale) {
+    public String getDocumentIconLink(ExternalDocumentServiceContext context, DocumentObject doc, Locale preferredLocale) {
         if (doc != null && doc.has("icon")) {
             return doc.getString("icon");
         }
@@ -188,16 +200,16 @@ public class ExampleExternalDocumentServiceFacade implements ExternalDocumentSer
         return "";
     }
 
-    private JSONObject findDocumentById(final String id) {
-        for (int i = 0; i < docArray.size(); i++) {
-            JSONObject doc = docArray.getJSONObject(i);
+    private DocumentObject findDocumentById(final String id) {
+        for (int i = 0; i < docArray.length(); i++) {
+            DocumentObject doc = (DocumentObject) docArray.get(i);
 
             if (StringUtils.equals(id, doc.getString("id"))) {
                 return doc;
             }
         }
 
-        return new JSONObject();
+        return new DocumentObject();
     }
 
 }

--- a/demo/cms/src/main/java/org/onehippo/forge/exdocpicker/demo/field/tree/ExampleExternalSubjectCategoryServiceFacade.java
+++ b/demo/cms/src/main/java/org/onehippo/forge/exdocpicker/demo/field/tree/ExampleExternalSubjectCategoryServiceFacade.java
@@ -31,7 +31,7 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.hippoecm.repository.HippoStdNodeType;
 import org.onehippo.forge.exdocpicker.api.ExternalDocumentCollection;
 import org.onehippo.forge.exdocpicker.api.ExternalDocumentServiceContext;

--- a/demo/cms/src/main/java/org/onehippo/forge/exdocpicker/demo/field/tree/SubjectCategory.java
+++ b/demo/cms/src/main/java/org/onehippo/forge/exdocpicker/demo/field/tree/SubjectCategory.java
@@ -20,7 +20,7 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
  * Subject category representation for a Mathematics Subject Classification.

--- a/demo/cms/src/main/java/org/onehippo/forge/exdocpicker/demo/jpa/field/SimpleJPQLExternalDocumentServiceFacade.java
+++ b/demo/cms/src/main/java/org/onehippo/forge/exdocpicker/demo/jpa/field/SimpleJPQLExternalDocumentServiceFacade.java
@@ -30,8 +30,8 @@ import javax.persistence.Persistence;
 import javax.persistence.Query;
 
 import org.apache.commons.beanutils.BeanUtils;
-import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.math.NumberUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.onehippo.forge.exdocpicker.api.ExternalDocumentCollection;
 import org.onehippo.forge.exdocpicker.api.ExternalDocumentServiceContext;
 import org.onehippo.forge.exdocpicker.api.ExternalDocumentServiceFacade;

--- a/demo/cms/src/main/webapp/examples/hippoblogarticles.jsp
+++ b/demo/cms/src/main/webapp/examples/hippoblogarticles.jsp
@@ -16,7 +16,7 @@ Simple JSON REST Service implementation only for demo purpose, supporting "?q=<s
 <%@ page import="java.util.*" %>
 <%@ page import="org.apache.commons.lang3.*" %>
 <%@ page import="org.apache.commons.io.*" %>
-<%@ page import="net.sf.json.*" %>
+<%@ page import="org.json.*" %>
 <%@ page import="java.nio.charset.StandardCharsets"%>
 
 <%!
@@ -33,7 +33,7 @@ private JSONObject transform(final JSONObject source) {
 
 <%
 final String data = IOUtils.toString(application.getResource("/WEB-INF/hippoblogarticles.json"), StandardCharsets.UTF_8);
-final JSONArray jsonData = JSONArray.fromObject(data);
+final JSONArray jsonData = new JSONArray(data.toString());
 final String id = request.getParameter("id");
 final String query = request.getParameter("q");
 
@@ -56,7 +56,7 @@ if (StringUtils.isNotBlank(id)) {
         }
     }
 
-    final int size = jsonData.size();
+    final int size = jsonData.length();
     out.println("[");
 
     for (int i = 0; i < size; i++) {

--- a/demo/cms/src/main/webapp/examples/msc.jsp
+++ b/demo/cms/src/main/webapp/examples/msc.jsp
@@ -15,11 +15,12 @@ Simple JSON REST Service implementation only for demo purpose, serializing examp
 <%@ page contentType="application/json" %>
 <%@ page import="org.apache.commons.lang3.*" %>
 <%@ page import="org.apache.commons.io.*" %>
-<%@ page import="net.sf.json.*" %><%@ page import="java.nio.charset.StandardCharsets"%>
+<%@ page import="org.json.*" %>
+<%@ page import="java.nio.charset.StandardCharsets"%>
 
 <%
 final String data = IOUtils.toString(application.getResource("/WEB-INF/msc.json"), StandardCharsets.UTF_8);
-final JSONArray jsonData = JSONArray.fromObject(data);
+final JSONArray jsonData = new JSONArray(data.toString());
 final String id = request.getParameter("id");
 
 if (StringUtils.isNotBlank(id)) {

--- a/demo/essentials/pom.xml
+++ b/demo/essentials/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.onehippo.forge.exdocpickerbase</groupId>
     <artifactId>exdocpickerbase-demo</artifactId>
-    <version>9.0.1-SNAPSHOT</version>
+    <version>9.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>exdocpickerbase-demo-essentials</artifactId>

--- a/demo/hsqldb/pom.xml
+++ b/demo/hsqldb/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.forge.exdocpickerbase</groupId>
     <artifactId>exdocpickerbase-demo</artifactId>
-    <version>9.0.1-SNAPSHOT</version>
+    <version>9.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Hippo CMS External Document Picker Base Demo Example HSQLDB</name>

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.cms7</groupId>
     <artifactId>hippo-cms7-release</artifactId>
-    <version>16.0.0</version>
+    <version>16.7.0</version>
     <relativePath></relativePath>
   </parent>
 
@@ -13,7 +13,7 @@
   <description>Hippo CMS External Document Picker Base Demo</description>
   <groupId>org.onehippo.forge.exdocpickerbase</groupId>
   <artifactId>exdocpickerbase-demo</artifactId>
-  <version>9.0.1-SNAPSHOT</version>
+  <version>9.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <!--
@@ -144,30 +144,13 @@
       </dependency>
 
       <dependency>
-        <groupId>net.sf.json-lib</groupId>
-        <artifactId>json-lib</artifactId>
-        <version>${json-lib.version}</version>
-        <classifier>jdk15</classifier>
-        <exclusions>
-          <exclusion>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-collections4</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-
-      <dependency>
         <groupId>org.apache.openjpa</groupId>
         <artifactId>openjpa</artifactId>
         <version>${openjpa.version}</version>
         <exclusions>
           <exclusion>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
           </exclusion>
           <exclusion>
             <groupId>org.apache.commons</groupId>
@@ -492,7 +475,7 @@
       <dependencies>
         <dependency>
           <groupId>org.apache.logging.log4j</groupId>
-          <artifactId>log4j-slf4j-impl</artifactId>
+          <artifactId>log4j-slf4j2-impl</artifactId>
           <scope>provided</scope>
         </dependency>
         <dependency>
@@ -540,7 +523,7 @@
       <dependencies>
         <dependency>
           <groupId>org.apache.logging.log4j</groupId>
-          <artifactId>log4j-slf4j-impl</artifactId>
+          <artifactId>log4j-slf4j2-impl</artifactId>
           <scope>provided</scope>
         </dependency>
         <dependency>

--- a/demo/repository-data/application/pom.xml
+++ b/demo/repository-data/application/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.forge.exdocpickerbase</groupId>
     <artifactId>exdocpickerbase-demo-repository-data</artifactId>
-    <version>9.0.1-SNAPSHOT</version>
+    <version>9.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Hippo CMS External Document Picker Base Demo Repository Data For Application</name>

--- a/demo/repository-data/development/pom.xml
+++ b/demo/repository-data/development/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.forge.exdocpickerbase</groupId>
     <artifactId>exdocpickerbase-demo-repository-data</artifactId>
-    <version>9.0.1-SNAPSHOT</version>
+    <version>9.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Hippo CMS External Document Picker Base Demo Repository Data For Development</name>

--- a/demo/repository-data/pom.xml
+++ b/demo/repository-data/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.forge.exdocpickerbase</groupId>
     <artifactId>exdocpickerbase-demo</artifactId>
-    <version>9.0.1-SNAPSHOT</version>
+    <version>9.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Hippo CMS External Document Picker Base Demo Repository Data</name>

--- a/demo/repository-data/site/pom.xml
+++ b/demo/repository-data/site/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.forge.exdocpickerbase</groupId>
     <artifactId>exdocpickerbase-demo-repository-data</artifactId>
-    <version>9.0.1-SNAPSHOT</version>
+    <version>9.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Hippo CMS External Document Picker Base Demo Repository Data For Site</name>

--- a/demo/repository-data/webfiles/pom.xml
+++ b/demo/repository-data/webfiles/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.forge.exdocpickerbase</groupId>
     <artifactId>exdocpickerbase-demo-repository-data</artifactId>
-    <version>9.0.1-SNAPSHOT</version>
+    <version>9.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Hippo CMS External Document Picker Base Demo Repository Data Web Files</name>

--- a/demo/site/components/pom.xml
+++ b/demo/site/components/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.forge.exdocpickerbase</groupId>
     <artifactId>exdocpickerbase-demo-site</artifactId>
-    <version>9.0.1-SNAPSHOT</version>
+    <version>9.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>exdocpickerbase-demo-components</artifactId>
   <packaging>jar</packaging>

--- a/demo/site/pom.xml
+++ b/demo/site/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.onehippo.forge.exdocpickerbase</groupId>
     <artifactId>exdocpickerbase-demo</artifactId>
-    <version>9.0.1-SNAPSHOT</version>
+    <version>9.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>exdocpickerbase-demo-site</artifactId>

--- a/demo/site/webapp/pom.xml
+++ b/demo/site/webapp/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.onehippo.forge.exdocpickerbase</groupId>
     <artifactId>exdocpickerbase-demo-site</artifactId>
-    <version>9.0.1-SNAPSHOT</version>
+    <version>9.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>exdocpickerbase-demo-webapp</artifactId>
@@ -28,7 +28,7 @@
     <dependency>
       <groupId>org.onehippo.forge.exdocpickerbase</groupId>
       <artifactId>exdocpickerbase-demo-components</artifactId>
-      <version>9.0.1-SNAPSHOT</version>
+      <version>9.1.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.onehippo.cms7.hst.toolkit-resources.addon</groupId>

--- a/demo/src/main/assembly/shared-lib-component.xml
+++ b/demo/src/main/assembly/shared-lib-component.xml
@@ -13,7 +13,7 @@
         <include>org.onehippo.cms7.hst:hst-api</include>
         <include>org.slf4j:slf4j-api</include>
         <include>org.slf4j:jcl-over-slf4j</include>
-        <include>org.apache.logging.log4j:log4j-slf4j-impl</include>
+        <include>org.apache.logging.log4j:log4j-slf4j2-impl</include>
         <include>org.apache.logging.log4j:log4j-api</include>
         <include>org.apache.logging.log4j:log4j-core</include>
       </includes>

--- a/fieldpicker/pom.xml
+++ b/fieldpicker/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.onehippo.forge.exdocpickerbase</groupId>
     <artifactId>exdocpickerbase</artifactId>
-    <version>9.0.1-SNAPSHOT</version>
+    <version>9.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Hippo CMS External Document Picker Base for Field Picker</name>
@@ -62,8 +62,9 @@
     </dependency>
 
     <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>${commons-lang3.version}</version>
       <scope>provided</scope>
     </dependency>
 
@@ -74,14 +75,6 @@
     </dependency>
 
     <!-- TEST DEPENDENCIES -->
-
-    <dependency>
-      <groupId>net.sf.json-lib</groupId>
-      <artifactId>json-lib</artifactId>
-      <classifier>jdk15</classifier>
-      <scope>test</scope>
-    </dependency>
-
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>
@@ -89,7 +82,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/fieldpicker/src/main/java/org/onehippo/forge/exdocpicker/impl/ServiceDelegatingExternalDocumentServiceFacade.java
+++ b/fieldpicker/src/main/java/org/onehippo/forge/exdocpicker/impl/ServiceDelegatingExternalDocumentServiceFacade.java
@@ -18,7 +18,7 @@ package org.onehippo.forge.exdocpicker.impl;
 import java.io.Serializable;
 import java.util.Locale;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.onehippo.forge.exdocpicker.api.ExternalDocumentCollection;
 import org.onehippo.forge.exdocpicker.api.ExternalDocumentServiceContext;
 import org.onehippo.forge.exdocpicker.api.ExternalDocumentServiceFacade;

--- a/fieldpicker/src/main/java/org/onehippo/forge/exdocpicker/impl/field/AbstractExternalDocumentFieldBrowserDialog.java
+++ b/fieldpicker/src/main/java/org/onehippo/forge/exdocpicker/impl/field/AbstractExternalDocumentFieldBrowserDialog.java
@@ -20,7 +20,7 @@ import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.util.value.IValueMap;
 import org.apache.wicket.util.value.ValueMap;

--- a/fieldpicker/src/main/java/org/onehippo/forge/exdocpicker/impl/field/ExternalDocumentFieldBrowserDialog.java
+++ b/fieldpicker/src/main/java/org/onehippo/forge/exdocpicker/impl/field/ExternalDocumentFieldBrowserDialog.java
@@ -18,7 +18,7 @@ package org.onehippo.forge.exdocpicker.impl.field;
 import java.io.Serializable;
 import java.util.Iterator;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.markup.html.form.AjaxButton;

--- a/fieldpicker/src/main/java/org/onehippo/forge/exdocpicker/impl/field/ExternalDocumentFieldSelectorPlugin.java
+++ b/fieldpicker/src/main/java/org/onehippo/forge/exdocpicker/impl/field/ExternalDocumentFieldSelectorPlugin.java
@@ -22,7 +22,7 @@ import java.util.NoSuchElementException;
 
 import javax.jcr.Node;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.MarkupContainer;
 import org.apache.wicket.ajax.AjaxRequestTarget;

--- a/fieldpicker/src/main/java/org/onehippo/forge/exdocpicker/impl/field/tree/ExternalTreeItemFieldBrowserDialog.java
+++ b/fieldpicker/src/main/java/org/onehippo/forge/exdocpicker/impl/field/tree/ExternalTreeItemFieldBrowserDialog.java
@@ -21,7 +21,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxRequestTarget;

--- a/fieldpicker/src/main/java/org/onehippo/forge/exdocpicker/impl/folder/ExternalDocumentFolderActionWorkflowMenuItemPlugin.java
+++ b/fieldpicker/src/main/java/org/onehippo/forge/exdocpicker/impl/folder/ExternalDocumentFolderActionWorkflowMenuItemPlugin.java
@@ -19,7 +19,7 @@ import java.io.Serializable;
 
 import javax.jcr.RepositoryException;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.model.StringResourceModel;

--- a/fieldpicker/src/test/java/org/onehippo/forge/exdocpicker/impl/DocumentObject.java
+++ b/fieldpicker/src/test/java/org/onehippo/forge/exdocpicker/impl/DocumentObject.java
@@ -1,0 +1,10 @@
+package org.onehippo.forge.exdocpicker.impl;
+
+import org.json.JSONObject;
+import java.io.Serializable;
+
+/**
+ * Object representing the document, extended from JSONObject to support serialization.
+ */
+public class DocumentObject extends JSONObject implements Serializable {
+}

--- a/fieldpicker/src/test/java/org/onehippo/forge/exdocpicker/impl/SimpleExternalDocumentCollectionTest.java
+++ b/fieldpicker/src/test/java/org/onehippo/forge/exdocpicker/impl/SimpleExternalDocumentCollectionTest.java
@@ -22,8 +22,6 @@ import static org.junit.Assert.assertTrue;
 import java.util.Arrays;
 import java.util.Iterator;
 
-import net.sf.json.JSONObject;
-
 import org.junit.Before;
 import org.junit.Test;
 
@@ -32,11 +30,11 @@ import org.junit.Test;
  */
 public class SimpleExternalDocumentCollectionTest {
 
-    private SimpleExternalDocumentCollection<JSONObject> docCollection;
+    private SimpleExternalDocumentCollection<DocumentObject> docCollection;
 
     @Before
     public void before() throws Exception {
-        docCollection = new SimpleExternalDocumentCollection<JSONObject>();
+        docCollection = new SimpleExternalDocumentCollection<DocumentObject>();
 
         for (int i = 1; i <= 10; i++) {
             docCollection.add(createDoc(i, "Document " + i));
@@ -65,11 +63,11 @@ public class SimpleExternalDocumentCollectionTest {
 
     @Test
     public void testIteration() throws Exception {
-        Iterator<? extends JSONObject> it = docCollection.iterator();
+        Iterator<? extends DocumentObject> it = docCollection.iterator();
 
         for (int i = 1; i <= 10; i++) {
             assertTrue(it.hasNext());
-            JSONObject item = it.next();
+            DocumentObject item = it.next();
             assertEquals(i, item.getInt("id"));
             assertEquals("Document " + i, item.getString("title"));
         }
@@ -80,25 +78,25 @@ public class SimpleExternalDocumentCollectionTest {
 
         for (int i = 6; i <= 9; i++) {
             assertTrue(it.hasNext());
-            JSONObject item = it.next();
+            DocumentObject item = it.next();
             assertEquals(i, item.getInt("id"));
             assertEquals("Document " + i, item.getString("title"));
         }
 
         assertFalse(it.hasNext());
 
-        JSONObject [] array = docCollection.toArray(new JSONObject[docCollection.getSize()]);
+        DocumentObject [] array = docCollection.toArray(new DocumentObject[docCollection.getSize()]);
         assertEquals(10, array.length);
 
         for (int i = 1; i <= 10; i++) {
-            JSONObject item = array[i - 1];
+            DocumentObject item = array[i - 1];
             assertEquals(i, item.getInt("id"));
             assertEquals("Document " + i, item.getString("title"));
         }
     }
 
-    private JSONObject createDoc(int id, String title) {
-        JSONObject doc = new JSONObject();
+    private DocumentObject createDoc(int id, String title) {
+        DocumentObject doc = new DocumentObject();
         doc.put("id", id);
         doc.put("title", title);
         return doc;

--- a/openui-fieldpicker/pom.xml
+++ b/openui-fieldpicker/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.onehippo.forge.exdocpickerbase</groupId>
     <artifactId>exdocpickerbase</artifactId>
-    <version>9.0.1-SNAPSHOT</version>
+    <version>9.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Hippo CMS External Document Picker Base for OpenUI Field Picker</name>

--- a/pom.xml
+++ b/pom.xml
@@ -16,14 +16,14 @@
   <parent>
     <groupId>org.onehippo.cms7</groupId>
     <artifactId>hippo-cms7-project</artifactId>
-    <version>16.0.0</version>
+    <version>16.7.0</version>
   </parent>
 
   <name>Hippo CMS External Document Picker Base</name>
   <description>Hippo CMS External Document Picker Base</description>
   <groupId>org.onehippo.forge.exdocpickerbase</groupId>
   <artifactId>exdocpickerbase</artifactId>
-  <version>9.0.1-SNAPSHOT</version>
+  <version>9.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <url>https://github.com/bloomreach-forge/external-document-picker/</url>
 
@@ -33,7 +33,6 @@
     <extension.wagon-svn.version>1.9</extension.wagon-svn.version>
 
     <!-- test dependencies -->
-    <lib.json-lib.version>2.4</lib.json-lib.version>
     <lib.junit.version>4.13.1</lib.junit.version>
     <lib.easymock.version>3.4</lib.easymock.version>
 
@@ -143,14 +142,13 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>${slf4j.version}</version>
+        <version>${slf4j2.version}</version>
         <scope>provided</scope>
       </dependency>
 
       <dependency>
-        <groupId>commons-lang</groupId>
-        <artifactId>commons-lang</artifactId>
-        <version>${commons-lang.version}</version>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
         <scope>provided</scope>
       </dependency>
 
@@ -162,24 +160,15 @@
       </dependency>
 
       <!-- TEST DEPENDENCIES -->
-
-      <dependency>
-        <groupId>net.sf.json-lib</groupId>
-        <artifactId>json-lib</artifactId>
-        <version>${lib.json-lib.version}</version>
-        <classifier>jdk15</classifier>
-        <scope>test</scope>
-      </dependency>
-
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>jcl-over-slf4j</artifactId>
-        <version>${slf4j.version}</version>
+        <version>${slf4j2.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-slf4j-impl</artifactId>
+        <artifactId>log4j-slf4j2-impl</artifactId>
         <version>${log4j2.version}</version>
         <scope>test</scope>
       </dependency>

--- a/richtext-ckeditor/pom.xml
+++ b/richtext-ckeditor/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.onehippo.forge.exdocpickerbase</groupId>
     <artifactId>exdocpickerbase</artifactId>
-    <version>9.0.1-SNAPSHOT</version>
+    <version>9.1.0-SNAPSHOT</version>
   </parent>
 
   <name>Hippo CMS External Document Picker Base for RichText Field in CKEditor</name>


### PR DESCRIPTION
Addressing 3 issues:

1. org.apache.commons.lang -> org.apache.commons.lang3
2. log4j-slf4j-impl -> log4j-slf4j2-impl
3. net.sf.json-lib was removed from brXM in favour of org.json (see https://xmdocumentation.bloomreach.com/library/upgrade-minor-versions/upgrade-16.1-to-16.2.html). This broke the test and the demo, but does not impact the actual plugin. Test and demo fixed by moving over to org.json since net.sf.json-lib is unmaintained.